### PR TITLE
Bugfix/update profile error

### DIFF
--- a/Moran_Jose.md
+++ b/Moran_Jose.md
@@ -1,0 +1,10 @@
+## Información del estudiante
+
+- Nombre completo: José Raúl Morán Henríquez
+- Carné: 00135321
+
+## Referencias a los Issues
+
+- Issue de feature: #70
+- Issue de bug: #65
+- Issue comentado (discusión): #159


### PR DESCRIPTION
Se corrigió el error que impedía actualizar el perfil del usuario, el cual causaba un `TypeError` por acceder a una propiedad de un input no definido.

Fixes #65